### PR TITLE
:arrow_up: Select openssl 1.1

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,12 @@
   "license": "MIT",
   "targetType": "library",
   "dependencies": {
-    "vibe-d": "~>0.8.3"
+    "vibe-d": "~>0.8.4",
+    "vibe-d:tls": "~>0.8.4"
+  },
+
+  "subConfigurations": {
+	  "vibe-d:tls": "openssl-1.1"
   },
 
   "configurations": [


### PR DESCRIPTION
Latest Linux distros don't support openssl 1.0 which appears to be vibe.d's default

https://github.com/rejectedsoftware/ddox/issues/186