### PR TITLE
Reduce try nesting

### DIFF
--- a/source/openapi/composites.d
+++ b/source/openapi/composites.d
@@ -83,32 +83,26 @@ auto validation(VibeHandler handler, OpenApi definitions) {
   void doValidation(HTTPServerRequest req, HTTPServerResponse res) {
     writeln(req.method.to!string ~ " " ~ req.path);
     try {
-      try {
-        try {
-          try {
-            req.validate!(ParameterIn.path)(definitions);
-            req.validate!(ParameterIn.query)(definitions);
-            req.validate!(ParameterIn.header)(definitions);
-            req.validateBody(definitions);
+      req.validate!(ParameterIn.path)(definitions);
+      req.validate!(ParameterIn.query)(definitions);
+      req.validate!(ParameterIn.header)(definitions);
+      req.validateBody(definitions);
 
-            handler(req, res);
-          } catch(OpenApiValidationException e) {
-            res.writeJsonBody(ErrorOutput(e), HTTPStatus.badRequest);
-            debug {
-              writeln(e);
-            }
-          }
-        } catch(OpenApiParameterException e) {
-          res.writeJsonBody(ErrorOutput(e), HTTPStatus.badRequest);
-          debug {
-            writeln(e);
-          }
-        }
-      } catch(OpenApiNotFoundException e) {
-        res.writeJsonBody(ErrorOutput(e), HTTPStatus.notFound);
-        debug {
-          writeln(e);
-        }
+      handler(req, res);
+    } catch(OpenApiValidationException e) {
+      res.writeJsonBody(ErrorOutput(e), HTTPStatus.badRequest);
+      debug {
+        writeln(e);
+      }
+    } catch(OpenApiParameterException e) {
+      res.writeJsonBody(ErrorOutput(e), HTTPStatus.badRequest);
+      debug {
+        writeln(e);
+      }
+    } catch(OpenApiNotFoundException e) {
+      res.writeJsonBody(ErrorOutput(e), HTTPStatus.notFound);
+      debug {
+        writeln(e);
       }
     } catch(Throwable e) {
       res.writeJsonBody(ErrorOutput(e), HTTPStatus.internalServerError);

--- a/source/openapi/validation.d
+++ b/source/openapi/validation.d
@@ -39,55 +39,53 @@ bool isValid(string value, string type, string format = "") {
   }
 
   try {
-    try {
-      if(type == "integer" && format == "int32") {
-        value.to!int;
-        return true;
-      }
+    if(type == "integer" && format == "int32") {
+      value.to!int;
+      return true;
+    }
 
-      if(type == "integer" && format == "int64") {
-        value.to!long;
-        return true;
-      }
+    if(type == "integer" && format == "int64") {
+      value.to!long;
+      return true;
+    }
 
-      if(type == "integer" && format == "") {
-        return value.isValid(type, "int32") || value.isValid(type, "int64");
-      }
+    if(type == "integer" && format == "") {
+      return value.isValid(type, "int32") || value.isValid(type, "int64");
+    }
 
-      if(type == "number" && format == "float") {
-        value.to!float;
-        return true;
-      }
+    if(type == "number" && format == "float") {
+      value.to!float;
+      return true;
+    }
 
-      if(type == "number" && format == "double") {
-        value.to!double;
-        return true;
-      }
+    if(type == "number" && format == "double") {
+      value.to!double;
+      return true;
+    }
 
-      if(type == "number" && format == "") {
-        return value.isValid(type, "double") || value.isValid(type, "float");
-      }
+    if(type == "number" && format == "") {
+      return value.isValid(type, "double") || value.isValid(type, "float");
+    }
 
-      if(type == "boolean") {
-        value.to!bool;
-        return true;
-      }
+    if(type == "boolean") {
+      value.to!bool;
+      return true;
+    }
 
-      if(type == "string" && format == "") {
-        return true;
-      }
+    if(type == "string" && format == "") {
+      return true;
+    }
 
-      if(type == "string" && format == "password") {
-        return true;
-      }
+    if(type == "string" && format == "password") {
+      return true;
+    }
 
-      if(type == "string" && format == "binary") {
-        return true;
-      }
-    } catch(ConvException e) {
-      return false;
+    if(type == "string" && format == "binary") {
+      return true;
     }
   } catch(ConvOverflowException e) {
+    return false;
+  } catch(ConvException e) {
     return false;
   }
 


### PR DESCRIPTION
The catch blocks for try can reside under a single try (they don't each need their own try).

This builds on my previous pull request because I can't build without that change.